### PR TITLE
Update contentIssabelPBX.php

### DIFF
--- a/modules/pbxadmin/libs/contentIssabelPBX.php
+++ b/modules/pbxadmin/libs/contentIssabelPBX.php
@@ -1,6 +1,7 @@
 <?php
 function getContent(&$smarty, $elx_module_name, $withList)
 {
+    global $fc_save;
     require_once "libs/misc.lib.php";
     $lang=get_language();
     $base_dir=dirname($_SERVER['SCRIPT_FILENAME']);


### PR DESCRIPTION
Fix featurecode not showing for global variable.  To reproduce the problem, from Issabel menu go to PBX > PBX Configuration > System Recordings > Add Recording , enter your extension and press `Go`.   The next description will say "...dial [""]..."  It should say "...dial *77..."